### PR TITLE
Feature: Add role name options

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,14 @@ module "serverless" {
   stage        = "${var.stage}"
 
   # (Default values)
-  # iam_region        = `*`
-  # iam_partition     = `*`
-  # iam_account_id    = `AWS_CALLER account`
-  # tf_service_name   = `tf-SERVICE_NAME`
-  # sls_service_name  = `sls-SERVICE_NAME`
+  # iam_region          = `*`
+  # iam_partition       = `*`
+  # iam_account_id      = `AWS_CALLER account`
+  # tf_service_name     = `tf-SERVICE_NAME`
+  # sls_service_name    = `sls-SERVICE_NAME`
+  # role_admin_name     = `admin`
+  # role_developer_name = `developer`
+  # role_ci_name        = `ci`
 }
 ```
 
@@ -168,6 +171,9 @@ Let's unpack the parameters a bit more (located in [variables.tf](variables.tf))
 - `iam_account_id`: The [AWS account ID][] to limit IAM privileges to. Defaults to the current caller's account ID.
 - `tf_service_name`: The service name for Terraform-created resources. It is very useful to distinguish between those created by Terraform / this module and those created by the Serverless framework. By default, `tf-${service_name}` for "Terraform". E.g., `tf-simple-reference` or `tf-sparklepants`.
 - `sls_service_name`: The service name for Serverless as defined in `serverless.yml` in the `service` field. Highly recommended to match our default of `sls-${service_name}` for "Serverless".
+- `role_admin_name`: The name for the IAM group, policy, etc. for administrators. (Default: `admin`).
+- `role_developer_name`: The name for the IAM group, policy, etc. for developers. (Default: `developer`).
+- `role_ci_name`: The name for the IAM group, policy, etc. for Continuous Integration (CI) / automation. (Default: `ci`).
 
 Most likely, an AWS superuser will be needed to run the Terraform application for these IAM / other resources.
 

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@
 
 # admin
 resource "aws_iam_group" "admin" {
-  name = "${local.tf_service_name}-${local.stage}-admin"
+  name = "${local.tf_service_name}-${local.stage}-${local.role_admin_name}"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_admin" {
@@ -28,7 +28,7 @@ resource "aws_iam_group_policy_attachment" "admin_developer" {
 
 # ci
 resource "aws_iam_group" "ci" {
-  name = "${local.tf_service_name}-${local.stage}-ci"
+  name = "${local.tf_service_name}-${local.stage}-${local.role_ci_name}"
 }
 
 resource "aws_iam_group_policy_attachment" "ci_developer" {
@@ -38,7 +38,7 @@ resource "aws_iam_group_policy_attachment" "ci_developer" {
 
 # developer
 resource "aws_iam_group" "developer" {
-  name = "${local.tf_service_name}-${local.stage}-developer"
+  name = "${local.tf_service_name}-${local.stage}-${local.role_developer_name}"
 }
 
 resource "aws_iam_group_policy_attachment" "developer_developer" {

--- a/modules/xray/README.md
+++ b/modules/xray/README.md
@@ -72,11 +72,14 @@ module "serverless_xray" {
   stage        = "${var.stage}"
 
   # (Default values)
-  # iam_region        = `*`
-  # iam_partition     = `*`
-  # iam_account_id    = `AWS_CALLER account`
-  # tf_service_name   = `tf-SERVICE_NAME`
-  # sls_service_name  = `sls-SERVICE_NAME`
+  # iam_region          = `*`
+  # iam_partition       = `*`
+  # iam_account_id      = `AWS_CALLER account`
+  # tf_service_name     = `tf-SERVICE_NAME`
+  # sls_service_name    = `sls-SERVICE_NAME`
+  # role_admin_name     = `admin`
+  # role_developer_name = `developer`
+  # role_ci_name        = `ci`
 }
 ```
 

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -51,19 +51,38 @@ variable "sls_service_name" {
   default     = ""
 }
 
+# Configurable names for roles. Default `admin|developer|ci`.
+variable "role_admin_name" {
+  description = "Administrator role name"
+  default     = "admin"
+}
+
+variable "role_developer_name" {
+  description = "Developer role name"
+  default     = "developer"
+}
+
+variable "role_ci_name" {
+  description = "Continuous Integration (CI) role name"
+  default     = "ci"
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 # AWS / Serverless framework configuration.
 locals {
-  iam_partition    = "${var.iam_partition}"
-  iam_account_id   = "${var.iam_account_id != "" ? var.iam_account_id : data.aws_caller_identity.current.account_id}"
-  region           = "${var.region != "" ? var.region : data.aws_region.current.name}"
-  iam_region       = "${var.iam_region}"
-  stage            = "${var.stage}"
-  service_name     = "${var.service_name}"
-  tf_service_name  = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
-  sls_service_name = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
+  iam_partition       = "${var.iam_partition}"
+  iam_account_id      = "${var.iam_account_id != "" ? var.iam_account_id : data.aws_caller_identity.current.account_id}"
+  region              = "${var.region != "" ? var.region : data.aws_region.current.name}"
+  iam_region          = "${var.iam_region}"
+  stage               = "${var.stage}"
+  service_name        = "${var.service_name}"
+  tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
+  sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
+  role_admin_name     = "${var.role_admin_name}"
+  role_developer_name = "${var.role_developer_name}"
+  role_ci_name        = "${var.role_ci_name}"
 
   tags = "${map(
     "Service", "${var.service_name}",

--- a/policy-admin.tf
+++ b/policy-admin.tf
@@ -6,7 +6,7 @@
 # - View metrics from `sls metrics`
 ###############################################################################
 resource "aws_iam_policy" "admin" {
-  name   = "${local.tf_service_name}-${local.stage}-admin"
+  name   = "${local.tf_service_name}-${local.stage}-${local.role_admin_name}"
   path   = "/"
   policy = "${data.aws_iam_policy_document.admin.json}"
 }

--- a/policy-developer.tf
+++ b/policy-developer.tf
@@ -6,7 +6,7 @@
 # - View logs and run various `serverless` commands
 ###############################################################################
 resource "aws_iam_policy" "developer" {
-  name   = "${local.tf_service_name}-${local.stage}-developer"
+  name   = "${local.tf_service_name}-${local.stage}-${local.role_developer_name}"
   path   = "/"
   policy = "${data.aws_iam_policy_document.developer.json}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,19 +51,38 @@ variable "sls_service_name" {
   default     = ""
 }
 
+# Configurable names for roles. Default `admin|developer|ci`.
+variable "role_admin_name" {
+  description = "Administrator role name"
+  default     = "admin"
+}
+
+variable "role_developer_name" {
+  description = "Developer role name"
+  default     = "developer"
+}
+
+variable "role_ci_name" {
+  description = "Continuous Integration (CI) role name"
+  default     = "ci"
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 # AWS / Serverless framework configuration.
 locals {
-  iam_partition    = "${var.iam_partition}"
-  iam_account_id   = "${var.iam_account_id != "" ? var.iam_account_id : data.aws_caller_identity.current.account_id}"
-  region           = "${var.region != "" ? var.region : data.aws_region.current.name}"
-  iam_region       = "${var.iam_region}"
-  stage            = "${var.stage}"
-  service_name     = "${var.service_name}"
-  tf_service_name  = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
-  sls_service_name = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
+  iam_partition       = "${var.iam_partition}"
+  iam_account_id      = "${var.iam_account_id != "" ? var.iam_account_id : data.aws_caller_identity.current.account_id}"
+  region              = "${var.region != "" ? var.region : data.aws_region.current.name}"
+  iam_region          = "${var.iam_region}"
+  stage               = "${var.stage}"
+  service_name        = "${var.service_name}"
+  tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
+  sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
+  role_admin_name     = "${var.role_admin_name}"
+  role_developer_name = "${var.role_developer_name}"
+  role_ci_name        = "${var.role_ci_name}"
 
   tags = "${map(
     "Service", "${var.service_name}",


### PR DESCRIPTION
I'm open for discussion as to whether or not we want this change, or to do it some other way...

- Adds `role_*_name` option to custom name IAM group, policy, etc. to something besides default `admin|developer|ci`. Fixes #25 

/cc @kevinmstephens @ianwsperber @tptee @jasonwilson @jjasonclark @declension