### PR TITLE
Support "many lambdas" scenario for developer|ci groups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes
 
 * Adds `opt_many_lambdas` option to allow Lambda function create/delete privileges for the `developer|ci` groups to facilitate application development around many independent functions.
   [#29](https://github.com/FormidableLabs/terraform-aws-serverless/issues/29)
+* Lock down `lambda:CreateFunction` to `sls_lambda_arn`.
+* Expand `logs:DescribeLogGroups` to wildcard-like `sls_log_stream_all_arn`. Needed for create-then-delete-then-create... scenario for functions.
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Adds `opt_many_lambdas` option to allow Lambda function create/delete privileges for the `developer|ci` groups to facilitate application development around many independent functions.
+  [#29](https://github.com/FormidableLabs/terraform-aws-serverless/issues/29)
+
 ## 0.1.1
 
 * Adds `role_*_name` option to name IAM groups, policies, etc. besides default `admin|developer|ci`.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ _Core IAM module_
     - `cloudwatch:GetMetricStatistics`
 * `developer|ci`:
     - `cloudformation:ValidateTemplate`
+* One of the above (depending on `opts_many_lambdas`):
+    - `logs:DescribeLogGroups`
 
 _X-ray submodule_
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ module "serverless" {
   # role_admin_name     = `admin`
   # role_developer_name = `developer`
   # role_ci_name        = `ci`
+  # opt_many_lambdas    = false
 }
 ```
 
@@ -176,6 +177,7 @@ Let's unpack the parameters a bit more (located in [variables.tf](variables.tf))
 - `role_admin_name`: The name for the IAM group, policy, etc. for administrators. (Default: `admin`).
 - `role_developer_name`: The name for the IAM group, policy, etc. for developers. (Default: `developer`).
 - `role_ci_name`: The name for the IAM group, policy, etc. for Continuous Integration (CI) / automation. (Default: `ci`).
+- `opt_many_lambdas`: By default, only the `admin` group can create and delete Lambda functions which gives extra security for a "mono-Lambda" application approach. However, many Lambda applications utilize multiple different functions which need to be created and deleted by the `developer` and `ci` group. Setting this option to `true` enables Lambda function create/delete privileges for all groups. (Default: `false`)
 
 Most likely, an AWS superuser will be needed to run the Terraform application for these IAM / other resources.
 

--- a/README.md
+++ b/README.md
@@ -77,14 +77,13 @@ _Core IAM module_
 * `admin`
     - `cloudformation:ListStacks`
     - `cloudformation:PreviewStackUpdate`
-    - `lambda:CreateFunction`
     - `lambda:GetEventSourceMapping`
     - `lambda:ListEventSourceMappings`
     - `lambda:ListFunctions`
     - `cloudwatch:GetMetricStatistics`
 * `developer|ci`:
     - `cloudformation:ValidateTemplate`
-* One of the above (depending on `opts_many_lambdas`):
+* One of the above (depending on `opt_many_lambdas`):
     - `logs:DescribeLogGroups`
 
 _X-ray submodule_

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,12 @@ resource "aws_iam_group_policy_attachment" "admin_admin" {
   policy_arn = "${aws_iam_policy.admin.arn}"
 }
 
+resource "aws_iam_group_policy_attachment" "admin_cd_lambdas" {
+  count      = "${local.opt_many_lambdas ? 0 : 1}"
+  group      = "${aws_iam_group.admin.name}"
+  policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
+}
+
 resource "aws_iam_group_policy_attachment" "admin_developer" {
   group      = "${aws_iam_group.admin.name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
@@ -36,6 +42,12 @@ resource "aws_iam_group_policy_attachment" "ci_developer" {
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
+resource "aws_iam_group_policy_attachment" "ci_cd_lambdas" {
+  count      = "${local.opt_many_lambdas ? 1 : 0}"
+  group      = "${aws_iam_group.ci.name}"
+  policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
+}
+
 # developer
 resource "aws_iam_group" "developer" {
   name = "${local.tf_service_name}-${local.stage}-${local.role_developer_name}"
@@ -44,4 +56,10 @@ resource "aws_iam_group" "developer" {
 resource "aws_iam_group_policy_attachment" "developer_developer" {
   group      = "${aws_iam_group.developer.name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
+}
+
+resource "aws_iam_group_policy_attachment" "developer_cd_lambdas" {
+  count      = "${local.opt_many_lambdas ? 1 : 0}"
+  group      = "${aws_iam_group.developer.name}"
+  policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,6 @@ resource "aws_iam_group_policy_attachment" "admin_admin" {
 }
 
 resource "aws_iam_group_policy_attachment" "admin_cd_lambdas" {
-  count      = "${local.opt_many_lambdas ? 0 : 1}"
   group      = "${aws_iam_group.admin.name}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -148,4 +148,8 @@ locals {
   # - **Note**: Adding `${local.iam_account_id}` will cause at least `-developer`
   #   to fail for permissions.
   sls_apigw_arn = "arn:${local.iam_partition}:apigateway:${local.iam_region}::/restapis*"
+
+  # All log streams.
+  # Needed for `logs:DescribeLogGroups`
+  sls_log_stream_all_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group::log-stream:"
 }

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -67,6 +67,11 @@ variable "role_ci_name" {
   default     = "ci"
 }
 
+variable "opt_many_lambdas" {
+  description = "Allow all groups (incl developer, ci) to create and delete Lambdas"
+  default     = false
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
@@ -83,6 +88,7 @@ locals {
   role_admin_name     = "${var.role_admin_name}"
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
+  opt_many_lambdas    = "${var.opt_many_lambdas}"
 
   tags = "${map(
     "Service", "${var.service_name}",

--- a/policy-admin.tf
+++ b/policy-admin.tf
@@ -77,7 +77,6 @@ data "aws_iam_policy_document" "admin" {
       "iam:CreateRole",
       "iam:DeleteRole",
       "iam:DetachRolePolicy",
-      "iam:PutRolePolicy",
       "iam:AttachRolePolicy",
       "iam:DeleteRolePolicy",
     ]
@@ -92,7 +91,6 @@ data "aws_iam_policy_document" "admin" {
     actions = [
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
-      "logs:DeleteLogGroup",
       "logs:PutLogEvents",
     ]
 

--- a/policy-admin.tf
+++ b/policy-admin.tf
@@ -53,21 +53,6 @@ data "aws_iam_policy_document" "admin" {
     ]
   }
 
-  # Lambda: Create, update, delete the serverless Lambda.
-  statement {
-    actions = [
-      "lambda:GetEventSourceMapping",
-      "lambda:ListEventSourceMappings",
-      "lambda:ListFunctions",
-    ]
-
-    # Necessary wildcards
-    # https://iam.cloudonaut.io/reference/lambda
-    resources = [
-      "*",
-    ]
-  }
-
   # IAM: Allow the built-in serverless framework Lambda Roles to hook up to the
   # Lambda.
   # - https://github.com/serverless/serverless/issues/1439#issuecomment-363383862

--- a/policy-admin.tf
+++ b/policy-admin.tf
@@ -86,19 +86,6 @@ data "aws_iam_policy_document" "admin" {
     ]
   }
 
-  # Logs (`sls deploy`, `sls logs`)
-  statement {
-    actions = [
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
-    resources = [
-      "${local.sls_log_stream_arn}",
-    ]
-  }
-
   # CloudWatch Events
   # https://serverless.com/framework/docs/providers/aws/events/cloudwatch-event/
   statement {

--- a/policy-admin.tf
+++ b/policy-admin.tf
@@ -56,7 +56,6 @@ data "aws_iam_policy_document" "admin" {
   # Lambda: Create, update, delete the serverless Lambda.
   statement {
     actions = [
-      "lambda:CreateFunction",
       "lambda:GetEventSourceMapping",
       "lambda:ListEventSourceMappings",
       "lambda:ListFunctions",
@@ -66,16 +65,6 @@ data "aws_iam_policy_document" "admin" {
     # https://iam.cloudonaut.io/reference/lambda
     resources = [
       "*",
-    ]
-  }
-
-  statement {
-    actions = [
-      "lambda:DeleteFunction",
-    ]
-
-    resources = [
-      "${local.sls_lambda_arn}",
     ]
   }
 

--- a/policy-cd-lambdas.tf
+++ b/policy-cd-lambdas.tf
@@ -56,7 +56,10 @@ data "aws_iam_policy_document" "cd_lambdas" {
 
   statement {
     actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
       "logs:DeleteLogGroup",
+      "logs:PutLogEvents",
     ]
 
     resources = [

--- a/policy-cd-lambdas.tf
+++ b/policy-cd-lambdas.tf
@@ -12,6 +12,9 @@ data "aws_iam_policy_document" "cd_lambdas" {
   statement {
     actions = [
       "lambda:CreateFunction",
+      "lambda:GetEventSourceMapping",
+      "lambda:ListEventSourceMappings",
+      "lambda:ListFunctions",
     ]
 
     # Necessary wildcards

--- a/policy-cd-lambdas.tf
+++ b/policy-cd-lambdas.tf
@@ -11,7 +11,6 @@ data "aws_iam_policy_document" "cd_lambdas" {
   # Lambda: Create, delete the serverless Lambda.
   statement {
     actions = [
-      "lambda:CreateFunction",
       "lambda:GetEventSourceMapping",
       "lambda:ListEventSourceMappings",
       "lambda:ListFunctions",
@@ -25,7 +24,10 @@ data "aws_iam_policy_document" "cd_lambdas" {
   }
 
   statement {
+    # Note: `lambda:CreateFunction` now supports function ARNs!
+    # https://docs.aws.amazon.com/lambda/latest/dg/lambda-api-permissions-ref.html
     actions = [
+      "lambda:CreateFunction",
       "lambda:DeleteFunction",
     ]
 

--- a/policy-cd-lambdas.tf
+++ b/policy-cd-lambdas.tf
@@ -30,4 +30,16 @@ data "aws_iam_policy_document" "cd_lambdas" {
       "${local.sls_lambda_arn}",
     ]
   }
+
+  # Logs (`sls logs`)
+  # - Need "all" ARN for `logs:DescribeLogGroups` in creating deleted Lambda.
+  statement {
+    actions = [
+      "logs:DescribeLogGroups",
+    ]
+
+    resources = [
+      "${local.sls_log_stream_all_arn}",
+    ]
+  }
 }

--- a/policy-cd-lambdas.tf
+++ b/policy-cd-lambdas.tf
@@ -31,6 +31,17 @@ data "aws_iam_policy_document" "cd_lambdas" {
     ]
   }
 
+  # IAM: Integrate Lambda roles.
+  statement {
+    actions = [
+      "iam:PutRolePolicy",
+    ]
+
+    resources = [
+      "${local.sls_lambda_role_arn}",
+    ]
+  }
+
   # Logs (`sls logs`)
   # - Need "all" ARN for `logs:DescribeLogGroups` in creating deleted Lambda.
   statement {
@@ -40,6 +51,16 @@ data "aws_iam_policy_document" "cd_lambdas" {
 
     resources = [
       "${local.sls_log_stream_all_arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "logs:DeleteLogGroup",
+    ]
+
+    resources = [
+      "${local.sls_log_stream_arn}",
     ]
   }
 }

--- a/policy-cd-lambdas.tf
+++ b/policy-cd-lambdas.tf
@@ -1,0 +1,33 @@
+###############################################################################
+# Policy: Create/Delete Lambdas
+###############################################################################
+resource "aws_iam_policy" "cd_lambdas" {
+  name   = "${local.tf_service_name}-${local.stage}-cd-lambdas"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.cd_lambdas.json}"
+}
+
+data "aws_iam_policy_document" "cd_lambdas" {
+  # Lambda: Create, delete the serverless Lambda.
+  statement {
+    actions = [
+      "lambda:CreateFunction",
+    ]
+
+    # Necessary wildcards
+    # https://iam.cloudonaut.io/reference/lambda
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "lambda:DeleteFunction",
+    ]
+
+    resources = [
+      "${local.sls_lambda_arn}",
+    ]
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -148,4 +148,8 @@ locals {
   # - **Note**: Adding `${local.iam_account_id}` will cause at least `-developer`
   #   to fail for permissions.
   sls_apigw_arn = "arn:${local.iam_partition}:apigateway:${local.iam_region}::/restapis*"
+
+  # All log streams.
+  # Needed for `logs:DescribeLogGroups`
+  sls_log_stream_all_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group::log-stream:"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,11 @@ variable "role_ci_name" {
   default     = "ci"
 }
 
+variable "opt_many_lambdas" {
+  description = "Allow all groups (incl developer, ci) to create and delete Lambdas"
+  default     = false
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
@@ -83,6 +88,7 @@ locals {
   role_admin_name     = "${var.role_admin_name}"
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
+  opt_many_lambdas    = "${var.opt_many_lambdas}"
 
   tags = "${map(
     "Service", "${var.service_name}",


### PR DESCRIPTION
- Adds new `opt_many_lambdas` flag to enable Lambda create/delete for `developer|ci` in addition to `admin`. (Default `false`). Fixes #29 
- Lock down `lambda:CreateFunction` to function ARN
- Add effective wildcard in `sls_log_stream_all_arn` for `logs:DescribeGroups` which is needed for create-then-delete in existing code. (Surfaced during testing).

/cc @tptee @ianwsperber @mscottx88 @alexdebrie