### PR TITLE
Move 'cloudformation:List|Get' permissions to dev|ci.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* Move `cloudformation:List|Get` permissions to `developer|ci` policy since they're limited already to `sls_cloudformation_arn`.
+  [#26](https://github.com/FormidableLabs/terraform-aws-serverless/issues/26)
+
 ## 0.2.0
 
 * Adds `opt_many_lambdas` option to allow Lambda function create/delete privileges for the `developer|ci` groups to facilitate application development around many independent functions.

--- a/policy-admin.tf
+++ b/policy-admin.tf
@@ -30,9 +30,6 @@ data "aws_iam_policy_document" "admin" {
     actions = [
       "cloudformation:CreateStack",
       "cloudformation:CreateUploadBucket",
-      "cloudformation:ListChangeSets",
-      "cloudformation:ListStackResources",
-      "cloudformation:Get*",
       "cloudformation:DeleteStack",
     ]
 

--- a/policy-developer.tf
+++ b/policy-developer.tf
@@ -30,6 +30,9 @@ data "aws_iam_policy_document" "developer" {
       "cloudformation:DescribeStackEvents",
       "cloudformation:DescribeStackResource",
       "cloudformation:DescribeStackResources",
+      "cloudformation:ListChangeSets",
+      "cloudformation:ListStackResources",
+      "cloudformation:Get*",
       "cloudformation:UpdateStack",
       "cloudformation:DescribeStacks",
     ]


### PR DESCRIPTION
* Move `cloudformation:List|Get` permissions to `developer|ci` policy since they're limited already to `sls_cloudformation_arn`. Fixes #26

/cc @declension -- Not sure if you still need this, but there seems to be no reason for me to _not_ move the `List|Get` cloudformation permissions scoped to a specific stack to the more permissive `developer|ci` policy. Let me know if this helps your original scenario if you have a moment to review!