### PR TITLE
Add group name outputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## Unreleased
+
+* Add IAM group name outputs for `admind|developer|ci`.
+  [#34](https://github.com/FormidableLabs/terraform-aws-serverless/issues/34)
+
 ## 0.2.1
 
 * Move `cloudformation:List|Get` permissions to `developer|ci` policy since they're limited already to `sls_cloudformation_arn`.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,2 +1,13 @@
 # Outputs
 
+output "iam_group_admin_name" {
+  value = "${aws_iam_group.admin.name}"
+}
+
+output "iam_group_developer_name" {
+  value = "${aws_iam_group.developer.name}"
+}
+
+output "iam_group_ci_name" {
+  value = "${aws_iam_group.ci.name}"
+}


### PR DESCRIPTION
Adds the three named group names (admin|developer|ci) for easier extension via policy attachments. Fixes #34 

/cc @shrugs 