### PR TITLE
BUG: Admin group needs new s3 encryption permissions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changes
 
 ## UNRELEASED
 
-* BUG: Add more IAM permissions after `serverless` framework introduced default S3 bucket encryption in [serverless/serverless#5800](https://github.com/serverless/serverless/pull/5800).
+* BUG: Add more IAM permissions after `serverless` framework introduced default S3 bucket encryption in [serverless/serverless#5800](https://github.com/serverless/serverless/pull/5800). _Note_ if you have an existing serverless deployment, after updating the Terraform support stack you will need to run an `admin` user serverless deploy to properly set the encryption configuration for subsequent `developer|ci` deploys.
   [#33](https://github.com/FormidableLabs/terraform-aws-serverless/issues/33)
 
 ## 0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes
 =======
 
+## UNRELEASED
+
+* BUG: Add more IAM permissions after `serverless` framework introduced default S3 bucket encryption in [serverless/serverless#5800](https://github.com/serverless/serverless/pull/5800).
+  [#33](https://github.com/FormidableLabs/terraform-aws-serverless/issues/33)
+
 ## 0.2.2
 
 * Add IAM group name outputs for `admind|developer|ci`.

--- a/policy-admin.tf
+++ b/policy-admin.tf
@@ -43,6 +43,8 @@ data "aws_iam_policy_document" "admin" {
     actions = [
       "s3:CreateBucket",
       "s3:DeleteBucket",
+      "s3:GetEncryptionConfiguration",
+      "s3:PutEncryptionConfiguration",
     ]
 
     resources = [


### PR DESCRIPTION


https://github.com/serverless/serverless/pull/5800 introduced default s3 deploy bucket encryption, creating upstream bugs like https://github.com/serverless/serverless/issues/5919 as well as in this project.

- Add s3 permissions properly scoped to bucket. Fixes #33 
- Verified fix in https://github.com/FormidableLabs/aws-lambda-serverless-reference 

/cc @shrugs