### PR TITLE
Allow for custom Lambda roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ module "serverless" {
   service_name = "sparklepants"
   stage        = "${var.stage}"
 
+  # lambda_role_name    = "your-custom-role"
+
   # (Default values)
   # iam_region          = `*`
   # iam_partition       = `*`
@@ -181,6 +183,7 @@ Let's unpack the parameters a bit more (located in [variables.tf](variables.tf))
 - `service_name`: A service name is something that defines the unique application that will match up with the serverless application. E.g., something boring like `simple-reference` or `graphql-server` or exciting like `unicorn` or `sparklepants`.
 - `stage`: The current stage that will match up with the `serverless` framework deployment. These are arbitrary, but can be something like `development`/`staging`/`production`.
 - `region`: The deployed region of the service. Defaults to the current caller's AWS region. E.g., `us-east-1`.
+- `lambda_role_name`: # A custom Lambda execution role to use instead of the Serverless default. Ensure that the custom role includes at least the same level of permissions as the default. If using the `xray` or `vpc` modules, make sure to pass this same option and role to them.
 - `iam_region`: The [AWS region][] to limit IAM privileges to. Defaults to `*`. The difference with `region` is that `region` has to be one specific region like `us-east-1` to match up with Serverless framework resources, whereas `iam_region` can be a single region or `*` wildcard as it's just an IAM restriction.
 - `iam_partition`: The [AWS partition][] to limit IAM privileges to. Defaults to `*`.
 - `iam_account_id`: The [AWS account ID][] to limit IAM privileges to. Defaults to the current caller's account ID.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ module "serverless" {
   service_name = "sparklepants"
   stage        = "${var.stage}"
 
-
   # (Default values)
   # iam_region          = `*`
   # iam_partition       = `*`

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ module "serverless" {
   service_name = "sparklepants"
   stage        = "${var.stage}"
 
-  # lambda_role_name    = "your-custom-role"
 
   # (Default values)
   # iam_region          = `*`
@@ -153,6 +152,7 @@ module "serverless" {
   # iam_account_id      = `AWS_CALLER account`
   # tf_service_name     = `tf-SERVICE_NAME`
   # sls_service_name    = `sls-SERVICE_NAME`
+  # lambda_role_name    = ""
   # role_admin_name     = `admin`
   # role_developer_name = `developer`
   # role_ci_name        = `ci`
@@ -183,7 +183,7 @@ Let's unpack the parameters a bit more (located in [variables.tf](variables.tf))
 - `service_name`: A service name is something that defines the unique application that will match up with the serverless application. E.g., something boring like `simple-reference` or `graphql-server` or exciting like `unicorn` or `sparklepants`.
 - `stage`: The current stage that will match up with the `serverless` framework deployment. These are arbitrary, but can be something like `development`/`staging`/`production`.
 - `region`: The deployed region of the service. Defaults to the current caller's AWS region. E.g., `us-east-1`.
-- `lambda_role_name`: # A custom Lambda execution role to use instead of the Serverless default. Ensure that the custom role includes at least the same level of permissions as the default. If using the `xray` or `vpc` modules, make sure to pass this same option and role to them.
+- `lambda_role_name`: A custom Lambda execution role to use instead of the Serverless default. Ensure that the custom role includes at least the same level of permissions as the default. If using the `xray` or `vpc` modules, make sure to pass this same option and role to them.
 - `iam_region`: The [AWS region][] to limit IAM privileges to. Defaults to `*`. The difference with `region` is that `region` has to be one specific region like `us-east-1` to match up with Serverless framework resources, whereas `iam_region` can be a single region or `*` wildcard as it's just an IAM restriction.
 - `iam_partition`: The [AWS partition][] to limit IAM privileges to. Defaults to `*`.
 - `iam_account_id`: The [AWS account ID][] to limit IAM privileges to. Defaults to the current caller's account ID.

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -52,7 +52,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Custom Lambda role to override the default Serverless one."
+  description = "Custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
   default     = ""
 }
 

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -51,6 +51,11 @@ variable "sls_service_name" {
   default     = ""
 }
 
+variable "lambda_role_name" {
+  description = "Custom Lambda role to override the default Serverless one."
+  default     = ""
+}
+
 # Configurable names for roles. Default `admin|developer|ci`.
 variable "role_admin_name" {
   description = "Administrator role name"
@@ -85,6 +90,7 @@ locals {
   service_name        = "${var.service_name}"
   tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
   sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
+  lambda_role_name    = "${var.lambda_role_name}"
   role_admin_name     = "${var.role_admin_name}"
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
@@ -126,7 +132,9 @@ locals {
   #
   # _Note_: We need **actual name** to match real role, which means
   # `local.region` and not `local.iam_region`.
-  sls_lambda_role_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
+  sls_lambda_role_default_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
+
+  sls_lambda_role_name = "${local.lambda_role_name != "" ? local.lambda_role_name : local.sls_lambda_role_default_name}"
 
   # The built-in serverless Lambda execution role ARN.
   #
@@ -134,7 +142,10 @@ locals {
   # in the actual name of the role.
   #
   # - No region allowed in ARN. See https://iam.cloudonaut.io/reference/iam.html
-  sls_lambda_role_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.stage}-${local.iam_region}-lambdaRole"
+  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.stage}-${local.iam_region}-lambdaRole"
+
+  sls_lambda_role_custom_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
+  sls_lambda_role_arn        = "${local.lambda_role_name != "" ? local.sls_lambda_role_custom_arn : local.sls_lambda_role_default_arn}"
 
   # The serverless created APIGW.
   #

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -52,7 +52,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Custom Lambda role to override the default Serverless one."
+  description = "Custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
   default     = ""
 }
 

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -51,6 +51,11 @@ variable "sls_service_name" {
   default     = ""
 }
 
+variable "lambda_role_name" {
+  description = "Custom Lambda role to override the default Serverless one."
+  default     = ""
+}
+
 # Configurable names for roles. Default `admin|developer|ci`.
 variable "role_admin_name" {
   description = "Administrator role name"
@@ -85,6 +90,7 @@ locals {
   service_name        = "${var.service_name}"
   tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
   sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
+  lambda_role_name    = "${var.lambda_role_name}"
   role_admin_name     = "${var.role_admin_name}"
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
@@ -126,7 +132,9 @@ locals {
   #
   # _Note_: We need **actual name** to match real role, which means
   # `local.region` and not `local.iam_region`.
-  sls_lambda_role_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
+  sls_lambda_role_default_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
+
+  sls_lambda_role_name = "${local.lambda_role_name != "" ? local.lambda_role_name : local.sls_lambda_role_default_name}"
 
   # The built-in serverless Lambda execution role ARN.
   #
@@ -134,7 +142,10 @@ locals {
   # in the actual name of the role.
   #
   # - No region allowed in ARN. See https://iam.cloudonaut.io/reference/iam.html
-  sls_lambda_role_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.stage}-${local.iam_region}-lambdaRole"
+  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.stage}-${local.iam_region}-lambdaRole"
+
+  sls_lambda_role_custom_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
+  sls_lambda_role_arn        = "${local.lambda_role_name != "" ? local.sls_lambda_role_custom_arn : local.sls_lambda_role_default_arn}"
 
   # The serverless created APIGW.
   #

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Custom Lambda role to override the default Serverless one."
+  description = "Custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,11 @@ variable "sls_service_name" {
   default     = ""
 }
 
+variable "lambda_role_name" {
+  description = "Custom Lambda role to override the default Serverless one."
+  default     = ""
+}
+
 # Configurable names for roles. Default `admin|developer|ci`.
 variable "role_admin_name" {
   description = "Administrator role name"
@@ -85,6 +90,7 @@ locals {
   service_name        = "${var.service_name}"
   tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
   sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
+  lambda_role_name    = "${var.lambda_role_name}"
   role_admin_name     = "${var.role_admin_name}"
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
@@ -126,7 +132,9 @@ locals {
   #
   # _Note_: We need **actual name** to match real role, which means
   # `local.region` and not `local.iam_region`.
-  sls_lambda_role_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
+  sls_lambda_role_default_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
+
+  sls_lambda_role_name = "${local.lambda_role_name != "" ? local.lambda_role_name : local.sls_lambda_role_default_name}"
 
   # The built-in serverless Lambda execution role ARN.
   #
@@ -134,7 +142,10 @@ locals {
   # in the actual name of the role.
   #
   # - No region allowed in ARN. See https://iam.cloudonaut.io/reference/iam.html
-  sls_lambda_role_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.stage}-${local.iam_region}-lambdaRole"
+  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.stage}-${local.iam_region}-lambdaRole"
+
+  sls_lambda_role_custom_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
+  sls_lambda_role_arn        = "${local.lambda_role_name != "" ? local.sls_lambda_role_custom_arn : local.sls_lambda_role_default_arn}"
 
   # The serverless created APIGW.
   #


### PR DESCRIPTION
Adds a `lambda_role_name` variable to override the default Serverless-generated Lambda execution role with a custom one. This is useful for:
- tweaking the default permissions
- avoiding a chicken-or-egg scenario when using the `xray` or `vpc` modules (i.e. `terraform init` failing to attach policies to the Serverless role because the Serverless stack doesn't yet exist)

Link to reference branch to verify [here](https://github.com/FormidableLabs/aws-lambda-serverless-reference/pull/19)