### PR TITLE
Add `iam_stage` option for loosening IAM stage permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ module "serverless" {
   # iam_region          = `*`
   # iam_partition       = `*`
   # iam_account_id      = `AWS_CALLER account`
+  # iam_stage           = `STAGE`
   # tf_service_name     = `tf-SERVICE_NAME`
   # sls_service_name    = `sls-SERVICE_NAME`
   # lambda_role_name    = ""
@@ -186,6 +187,7 @@ Let's unpack the parameters a bit more (located in [variables.tf](variables.tf))
 - `iam_region`: The [AWS region][] to limit IAM privileges to. Defaults to `*`. The difference with `region` is that `region` has to be one specific region like `us-east-1` to match up with Serverless framework resources, whereas `iam_region` can be a single region or `*` wildcard as it's just an IAM restriction.
 - `iam_partition`: The [AWS partition][] to limit IAM privileges to. Defaults to `*`.
 - `iam_account_id`: The [AWS account ID][] to limit IAM privileges to. Defaults to the current caller's account ID.
+- `iam_stage`: The stage to limit IAM privileges to. Defaults to the `stage` variable. Wildcarding stage (e.g. `nonprod-*`) is a strategy for isolating dynamic environments (e.g. pull request environments) from production ones.
 - `tf_service_name`: The service name for Terraform-created resources. It is very useful to distinguish between those created by Terraform / this module and those created by the Serverless framework. By default, `tf-${service_name}` for "Terraform". E.g., `tf-simple-reference` or `tf-sparklepants`.
 - `sls_service_name`: The service name for Serverless as defined in `serverless.yml` in the `service` field. Highly recommended to match our default of `sls-${service_name}` for "Serverless".
 - `role_admin_name`: The name for the IAM group, policy, etc. for administrators. (Default: `admin`).

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -148,7 +148,7 @@ locals {
   # in the actual name of the role.
   #
   # - No region allowed in ARN. See https://iam.cloudonaut.io/reference/iam.html
-  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.stage}-${local.iam_region}-lambdaRole"
+  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.iam_stage}-${local.iam_region}-lambdaRole"
 
   sls_lambda_role_custom_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
   sls_lambda_role_arn        = "${local.lambda_role_name != "" ? local.sls_lambda_role_custom_arn : local.sls_lambda_role_default_arn}"

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -33,6 +33,10 @@ variable "stage" {
   default     = "development"
 }
 
+variable "iam_stage" {
+  description = "The IAM stage restriction for permissions. Wildcarding stage is useful for dynamic environment creation."
+}
+
 variable "service_name" {
   description = "Name of service / application"
 }
@@ -87,6 +91,7 @@ locals {
   region              = "${var.region != "" ? var.region : data.aws_region.current.name}"
   iam_region          = "${var.iam_region}"
   stage               = "${var.stage}"
+  iam_stage           = "${var.iam_stage != "" ? var.iam_stage : var.stage}"
   service_name        = "${var.service_name}"
   tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
   sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
@@ -110,7 +115,7 @@ locals {
   tf_group_ci_name        = "${local.tf_service_name}-${local.stage}-${local.role_ci_name}"
 
   # Serverless CloudFormation stack ARN.
-  sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.stage}/*"
+  sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"
 
   # Serverless target deployment bucket ARN.
   # - A long service name can endup with truncated bucket names like:
@@ -120,13 +125,13 @@ locals {
   sls_deploy_bucket_arn = "arn:${local.iam_partition}:s3:::${local.sls_service_name}-*-serverless*-*"
 
   # Serverless created log stream.
-  sls_log_stream_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group:/aws/lambda/${local.sls_service_name}-${local.stage}-*:log-stream:"
+  sls_log_stream_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group:/aws/lambda/${local.sls_service_name}-${local.iam_stage}-*:log-stream:"
 
   # Serverless created CloudWatch events.
-  sls_events_arn = "arn:${local.iam_partition}:events:${local.iam_region}:${local.iam_account_id}:rule/${local.sls_service_name}-${local.stage}"
+  sls_events_arn = "arn:${local.iam_partition}:events:${local.iam_region}:${local.iam_account_id}:rule/${local.sls_service_name}-${local.iam_stage}"
 
   # Serverless lambda function ARN.
-  sls_lambda_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:function:${local.sls_service_name}-${local.stage}-*"
+  sls_lambda_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:function:${local.sls_service_name}-${local.iam_stage}-*"
 
   # The built-in serverless Lambda execution role.
   #
@@ -134,6 +139,7 @@ locals {
   # `local.region` and not `local.iam_region`.
   sls_lambda_role_default_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
 
+  # The name, custom or default, of the Lambda execution role to attach policies to.
   sls_lambda_role_name = "${local.lambda_role_name != "" ? local.lambda_role_name : local.sls_lambda_role_default_name}"
 
   # The built-in serverless Lambda execution role ARN.

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -148,7 +148,7 @@ locals {
   # in the actual name of the role.
   #
   # - No region allowed in ARN. See https://iam.cloudonaut.io/reference/iam.html
-  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.stage}-${local.iam_region}-lambdaRole"
+  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.iam_stage}-${local.iam_region}-lambdaRole"
 
   sls_lambda_role_custom_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
   sls_lambda_role_arn        = "${local.lambda_role_name != "" ? local.sls_lambda_role_custom_arn : local.sls_lambda_role_default_arn}"

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -33,6 +33,10 @@ variable "stage" {
   default     = "development"
 }
 
+variable "iam_stage" {
+  description = "The IAM stage restriction for permissions. Wildcarding stage is useful for dynamic environment creation."
+}
+
 variable "service_name" {
   description = "Name of service / application"
 }
@@ -87,6 +91,7 @@ locals {
   region              = "${var.region != "" ? var.region : data.aws_region.current.name}"
   iam_region          = "${var.iam_region}"
   stage               = "${var.stage}"
+  iam_stage           = "${var.iam_stage != "" ? var.iam_stage : var.stage}"
   service_name        = "${var.service_name}"
   tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
   sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
@@ -110,7 +115,7 @@ locals {
   tf_group_ci_name        = "${local.tf_service_name}-${local.stage}-${local.role_ci_name}"
 
   # Serverless CloudFormation stack ARN.
-  sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.stage}/*"
+  sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"
 
   # Serverless target deployment bucket ARN.
   # - A long service name can endup with truncated bucket names like:
@@ -120,13 +125,13 @@ locals {
   sls_deploy_bucket_arn = "arn:${local.iam_partition}:s3:::${local.sls_service_name}-*-serverless*-*"
 
   # Serverless created log stream.
-  sls_log_stream_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group:/aws/lambda/${local.sls_service_name}-${local.stage}-*:log-stream:"
+  sls_log_stream_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group:/aws/lambda/${local.sls_service_name}-${local.iam_stage}-*:log-stream:"
 
   # Serverless created CloudWatch events.
-  sls_events_arn = "arn:${local.iam_partition}:events:${local.iam_region}:${local.iam_account_id}:rule/${local.sls_service_name}-${local.stage}"
+  sls_events_arn = "arn:${local.iam_partition}:events:${local.iam_region}:${local.iam_account_id}:rule/${local.sls_service_name}-${local.iam_stage}"
 
   # Serverless lambda function ARN.
-  sls_lambda_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:function:${local.sls_service_name}-${local.stage}-*"
+  sls_lambda_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:function:${local.sls_service_name}-${local.iam_stage}-*"
 
   # The built-in serverless Lambda execution role.
   #
@@ -134,6 +139,7 @@ locals {
   # `local.region` and not `local.iam_region`.
   sls_lambda_role_default_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
 
+  # The name, custom or default, of the Lambda execution role to attach policies to.
   sls_lambda_role_name = "${local.lambda_role_name != "" ? local.lambda_role_name : local.sls_lambda_role_default_name}"
 
   # The built-in serverless Lambda execution role ARN.

--- a/variables.tf
+++ b/variables.tf
@@ -148,7 +148,7 @@ locals {
   # in the actual name of the role.
   #
   # - No region allowed in ARN. See https://iam.cloudonaut.io/reference/iam.html
-  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.stage}-${local.iam_region}-lambdaRole"
+  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.iam_stage}-${local.iam_region}-lambdaRole"
 
   sls_lambda_role_custom_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
   sls_lambda_role_arn        = "${local.lambda_role_name != "" ? local.sls_lambda_role_custom_arn : local.sls_lambda_role_default_arn}"

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,10 @@ variable "stage" {
   default     = "development"
 }
 
+variable "iam_stage" {
+  description = "The IAM stage restriction for permissions. Wildcarding stage is useful for dynamic environment creation."
+}
+
 variable "service_name" {
   description = "Name of service / application"
 }
@@ -87,6 +91,7 @@ locals {
   region              = "${var.region != "" ? var.region : data.aws_region.current.name}"
   iam_region          = "${var.iam_region}"
   stage               = "${var.stage}"
+  iam_stage           = "${var.iam_stage != "" ? var.iam_stage : var.stage}"
   service_name        = "${var.service_name}"
   tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
   sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
@@ -110,7 +115,7 @@ locals {
   tf_group_ci_name        = "${local.tf_service_name}-${local.stage}-${local.role_ci_name}"
 
   # Serverless CloudFormation stack ARN.
-  sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.stage}/*"
+  sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"
 
   # Serverless target deployment bucket ARN.
   # - A long service name can endup with truncated bucket names like:
@@ -120,13 +125,13 @@ locals {
   sls_deploy_bucket_arn = "arn:${local.iam_partition}:s3:::${local.sls_service_name}-*-serverless*-*"
 
   # Serverless created log stream.
-  sls_log_stream_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group:/aws/lambda/${local.sls_service_name}-${local.stage}-*:log-stream:"
+  sls_log_stream_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group:/aws/lambda/${local.sls_service_name}-${local.iam_stage}-*:log-stream:"
 
   # Serverless created CloudWatch events.
-  sls_events_arn = "arn:${local.iam_partition}:events:${local.iam_region}:${local.iam_account_id}:rule/${local.sls_service_name}-${local.stage}"
+  sls_events_arn = "arn:${local.iam_partition}:events:${local.iam_region}:${local.iam_account_id}:rule/${local.sls_service_name}-${local.iam_stage}"
 
   # Serverless lambda function ARN.
-  sls_lambda_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:function:${local.sls_service_name}-${local.stage}-*"
+  sls_lambda_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:function:${local.sls_service_name}-${local.iam_stage}-*"
 
   # The built-in serverless Lambda execution role.
   #
@@ -134,6 +139,7 @@ locals {
   # `local.region` and not `local.iam_region`.
   sls_lambda_role_default_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
 
+  # The name, custom or default, of the Lambda execution role to attach policies to.
   sls_lambda_role_name = "${local.lambda_role_name != "" ? local.lambda_role_name : local.sls_lambda_role_default_name}"
 
   # The built-in serverless Lambda execution role ARN.


### PR DESCRIPTION
This option allows redefinition how IAM protects each stage. This is particularly useful for the following scheme:

- Two IAM Terraform stacks, one of stage `nonprod` and one of stage `production`.
- Multiple Serverless apps, created by pull requests, of stage `nonprod-pr-*` (e.g. `nonprod-pr-123`).
- A single production Serverless app of stage `production`.

Wildcarding stage to be `nonprod-*` in the nonprod module invocation allows the CI role to create dynamic Serverless deployments without the elevated privileges needed to define and edit IAM. The `nonprod` prefix also prevents these dynamic environments from accessing production Serverless in any way.

Verified that logs, invocation, and X-Ray function as expected with the following updated branch in our AWS account: https://github.com/FormidableLabs/aws-lambda-serverless-reference/tree/feature/custom-lambda-role