### PR TITLE
Add default value to iam_region variable

### DIFF
--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -35,6 +35,7 @@ variable "stage" {
 
 variable "iam_stage" {
   description = "The IAM stage restriction for permissions. Wildcarding stage is useful for dynamic environment creation."
+  default     = ""
 }
 
 variable "service_name" {

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -35,6 +35,7 @@ variable "stage" {
 
 variable "iam_stage" {
   description = "The IAM stage restriction for permissions. Wildcarding stage is useful for dynamic environment creation."
+  default     = ""
 }
 
 variable "service_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,7 @@ variable "stage" {
 
 variable "iam_stage" {
   description = "The IAM stage restriction for permissions. Wildcarding stage is useful for dynamic environment creation."
+  default     = ""
 }
 
 variable "service_name" {


### PR DESCRIPTION
In introducing the `iam_stage`, I forgot to set a default (even though `local.iam_stage`  assumes an empty default). This fixes that!