### PR TITLE
Replace sls lambda role with a new default one

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ custom:
 
 provider:
   name: aws
+  # Use the role provided by `terraform-aws-serverless.`
+  # 
+  # **NOTE**: terraform-aws-serverless uses its own Lambda execution role
+  # in favor of the Serverless default. It has the same permissions, but
+  # allows you to attach IAM policies to it before running `sls deploy`.
+  # This prevents failures when trying to run Terraform before deploying
+  # your Serverless app.
+  role:
+    Fn::ImportValue: tf-${self:custom.service}-${self:custom.stage}-LambdaExecutionRoleArn
   runtime: nodejs8.10
   region: "us-east-1"
   stage: ${self:custom.stage}
@@ -198,7 +207,7 @@ Let's unpack the parameters a bit more (located in [variables.tf](variables.tf))
 - `service_name`: A service name is something that defines the unique application that will match up with the serverless application. E.g., something boring like `simple-reference` or `graphql-server` or exciting like `unicorn` or `sparklepants`.
 - `stage`: The current stage that will match up with the `serverless` framework deployment. These are arbitrary, but can be something like `development`/`staging`/`production`.
 - `region`: The deployed region of the service. Defaults to the current caller's AWS region. E.g., `us-east-1`.
-- `lambda_role_name`: A custom Lambda execution role to use instead of the Serverless default. Ensure that the custom role includes at least the same level of permissions as the default. If using the `xray` or `vpc` modules, make sure to pass this same option and role to them.
+- `lambda_role_name`: A custom Lambda execution role to use instead of the module default. If using the `xray` or `vpc` modules, make sure to pass this same option and role to them.
 - `iam_region`: The [AWS region][] to limit IAM privileges to. Defaults to `*`. The difference with `region` is that `region` has to be one specific region like `us-east-1` to match up with Serverless framework resources, whereas `iam_region` can be a single region or `*` wildcard as it's just an IAM restriction.
 - `iam_partition`: The [AWS partition][] to limit IAM privileges to. Defaults to `*`.
 - `iam_account_id`: The [AWS account ID][] to limit IAM privileges to. Defaults to the current caller's account ID.

--- a/modules/canary/variables.tf
+++ b/modules/canary/variables.tf
@@ -57,7 +57,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
+  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default. If not specified, the role name defaults to `tf-SERVICE_NAME-STAGE-lambda-execution`."
   default     = ""
 }
 

--- a/modules/canary/variables.tf
+++ b/modules/canary/variables.tf
@@ -57,7 +57,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
+  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
   default     = ""
 }
 
@@ -82,12 +82,15 @@ variable "opt_many_lambdas" {
   default     = false
 }
 
+data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 # AWS / Serverless framework configuration.
 locals {
+  partition           = "${data.aws_partition.current.partition}"
   iam_partition       = "${var.iam_partition}"
+  account_id          = "${data.aws_caller_identity.current.account_id}"
   iam_account_id      = "${var.iam_account_id != "" ? var.iam_account_id : data.aws_caller_identity.current.account_id}"
   region              = "${var.region != "" ? var.region : data.aws_region.current.name}"
   iam_region          = "${var.iam_region}"
@@ -96,7 +99,6 @@ locals {
   service_name        = "${var.service_name}"
   tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
   sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
-  lambda_role_name    = "${var.lambda_role_name}"
   role_admin_name     = "${var.role_admin_name}"
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
@@ -114,6 +116,11 @@ locals {
   tf_group_admin_name     = "${local.tf_service_name}-${local.stage}-${local.role_admin_name}"
   tf_group_developer_name = "${local.tf_service_name}-${local.stage}-${local.role_developer_name}"
   tf_group_ci_name        = "${local.tf_service_name}-${local.stage}-${local.role_ci_name}"
+
+  # Resolve the name and ARN for either the default or the custom role.
+  default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
+  lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
+  lambda_role_arn          = "arn:aws:${local.partition}::${local.account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.
   sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"
@@ -133,26 +140,6 @@ locals {
 
   # Serverless lambda function ARN.
   sls_lambda_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:function:${local.sls_service_name}-${local.iam_stage}-*"
-
-  # The built-in serverless Lambda execution role.
-  #
-  # _Note_: We need **actual name** to match real role, which means
-  # `local.region` and not `local.iam_region`.
-  sls_lambda_role_default_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
-
-  # The name, custom or default, of the Lambda execution role to attach policies to.
-  sls_lambda_role_name = "${local.lambda_role_name != "" ? local.lambda_role_name : local.sls_lambda_role_default_name}"
-
-  # The built-in serverless Lambda execution role ARN.
-  #
-  # Note that we use `iam_region` to potentially wildcard the IAM permission
-  # in the actual name of the role.
-  #
-  # - No region allowed in ARN. See https://iam.cloudonaut.io/reference/iam.html
-  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.iam_stage}-${local.iam_region}-lambdaRole"
-
-  sls_lambda_role_custom_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
-  sls_lambda_role_arn        = "${local.lambda_role_name != "" ? local.sls_lambda_role_custom_arn : local.sls_lambda_role_default_arn}"
 
   # Serverless Lambda Layer ARN.
   sls_layer_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:layer:${local.sls_service_name}-${local.iam_stage}-*"

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -4,7 +4,7 @@
 
 # SLS-built-in lambda role
 resource "aws_iam_role_policy_attachment" "lambda_execution" {
-  role       = "${local.sls_lambda_role_name}"
+  role       = "${local.lambda_role_name}"
   policy_arn = "${aws_iam_policy.lambda_execution.arn}"
 }
 

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -57,7 +57,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
+  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default. If not specified, the role name defaults to `tf-SERVICE_NAME-STAGE-lambda-execution`."
   default     = ""
 }
 

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -57,7 +57,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
+  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
   default     = ""
 }
 
@@ -82,12 +82,15 @@ variable "opt_many_lambdas" {
   default     = false
 }
 
+data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 # AWS / Serverless framework configuration.
 locals {
+  partition           = "${data.aws_partition.current.partition}"
   iam_partition       = "${var.iam_partition}"
+  account_id          = "${data.aws_caller_identity.current.account_id}"
   iam_account_id      = "${var.iam_account_id != "" ? var.iam_account_id : data.aws_caller_identity.current.account_id}"
   region              = "${var.region != "" ? var.region : data.aws_region.current.name}"
   iam_region          = "${var.iam_region}"
@@ -96,7 +99,6 @@ locals {
   service_name        = "${var.service_name}"
   tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
   sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
-  lambda_role_name    = "${var.lambda_role_name}"
   role_admin_name     = "${var.role_admin_name}"
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
@@ -114,6 +116,11 @@ locals {
   tf_group_admin_name     = "${local.tf_service_name}-${local.stage}-${local.role_admin_name}"
   tf_group_developer_name = "${local.tf_service_name}-${local.stage}-${local.role_developer_name}"
   tf_group_ci_name        = "${local.tf_service_name}-${local.stage}-${local.role_ci_name}"
+
+  # Resolve the name and ARN for either the default or the custom role.
+  default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
+  lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
+  lambda_role_arn          = "arn:aws:${local.partition}::${local.account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.
   sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"
@@ -133,26 +140,6 @@ locals {
 
   # Serverless lambda function ARN.
   sls_lambda_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:function:${local.sls_service_name}-${local.iam_stage}-*"
-
-  # The built-in serverless Lambda execution role.
-  #
-  # _Note_: We need **actual name** to match real role, which means
-  # `local.region` and not `local.iam_region`.
-  sls_lambda_role_default_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
-
-  # The name, custom or default, of the Lambda execution role to attach policies to.
-  sls_lambda_role_name = "${local.lambda_role_name != "" ? local.lambda_role_name : local.sls_lambda_role_default_name}"
-
-  # The built-in serverless Lambda execution role ARN.
-  #
-  # Note that we use `iam_region` to potentially wildcard the IAM permission
-  # in the actual name of the role.
-  #
-  # - No region allowed in ARN. See https://iam.cloudonaut.io/reference/iam.html
-  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.iam_stage}-${local.iam_region}-lambdaRole"
-
-  sls_lambda_role_custom_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
-  sls_lambda_role_arn        = "${local.lambda_role_name != "" ? local.sls_lambda_role_custom_arn : local.sls_lambda_role_default_arn}"
 
   # Serverless Lambda Layer ARN.
   sls_layer_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:layer:${local.sls_service_name}-${local.iam_stage}-*"

--- a/modules/xray/main.tf
+++ b/modules/xray/main.tf
@@ -4,6 +4,6 @@
 
 # SLS-built-in lambda role
 resource "aws_iam_role_policy_attachment" "lambda_execution" {
-  role       = "${local.sls_lambda_role_name}"
+  role       = "${local.lambda_role_name}"
   policy_arn = "${aws_iam_policy.lambda_execution.arn}"
 }

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -57,7 +57,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
+  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default. If not specified, the role name defaults to `tf-SERVICE_NAME-STAGE-lambda-execution`."
   default     = ""
 }
 

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -57,7 +57,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
+  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
   default     = ""
 }
 
@@ -82,12 +82,15 @@ variable "opt_many_lambdas" {
   default     = false
 }
 
+data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 # AWS / Serverless framework configuration.
 locals {
+  partition           = "${data.aws_partition.current.partition}"
   iam_partition       = "${var.iam_partition}"
+  account_id          = "${data.aws_caller_identity.current.account_id}"
   iam_account_id      = "${var.iam_account_id != "" ? var.iam_account_id : data.aws_caller_identity.current.account_id}"
   region              = "${var.region != "" ? var.region : data.aws_region.current.name}"
   iam_region          = "${var.iam_region}"
@@ -96,7 +99,6 @@ locals {
   service_name        = "${var.service_name}"
   tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
   sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
-  lambda_role_name    = "${var.lambda_role_name}"
   role_admin_name     = "${var.role_admin_name}"
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
@@ -114,6 +116,11 @@ locals {
   tf_group_admin_name     = "${local.tf_service_name}-${local.stage}-${local.role_admin_name}"
   tf_group_developer_name = "${local.tf_service_name}-${local.stage}-${local.role_developer_name}"
   tf_group_ci_name        = "${local.tf_service_name}-${local.stage}-${local.role_ci_name}"
+
+  # Resolve the name and ARN for either the default or the custom role.
+  default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
+  lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
+  lambda_role_arn          = "arn:aws:${local.partition}::${local.account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.
   sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"
@@ -133,26 +140,6 @@ locals {
 
   # Serverless lambda function ARN.
   sls_lambda_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:function:${local.sls_service_name}-${local.iam_stage}-*"
-
-  # The built-in serverless Lambda execution role.
-  #
-  # _Note_: We need **actual name** to match real role, which means
-  # `local.region` and not `local.iam_region`.
-  sls_lambda_role_default_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
-
-  # The name, custom or default, of the Lambda execution role to attach policies to.
-  sls_lambda_role_name = "${local.lambda_role_name != "" ? local.lambda_role_name : local.sls_lambda_role_default_name}"
-
-  # The built-in serverless Lambda execution role ARN.
-  #
-  # Note that we use `iam_region` to potentially wildcard the IAM permission
-  # in the actual name of the role.
-  #
-  # - No region allowed in ARN. See https://iam.cloudonaut.io/reference/iam.html
-  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.iam_stage}-${local.iam_region}-lambdaRole"
-
-  sls_lambda_role_custom_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
-  sls_lambda_role_arn        = "${local.lambda_role_name != "" ? local.sls_lambda_role_custom_arn : local.sls_lambda_role_default_arn}"
 
   # Serverless Lambda Layer ARN.
   sls_layer_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:layer:${local.sls_service_name}-${local.iam_stage}-*"

--- a/policy-admin.tf
+++ b/policy-admin.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "admin" {
     ]
 
     resources = [
-      "${local.sls_lambda_role_arn}",
+      "${local.lambda_role_arn}",
     ]
   }
 

--- a/policy-cd-lambdas.tf
+++ b/policy-cd-lambdas.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "cd_lambdas" {
     ]
 
     resources = [
-      "${local.sls_lambda_role_arn}",
+      "${local.lambda_role_arn}",
     ]
   }
 

--- a/policy-developer.tf
+++ b/policy-developer.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "developer" {
     ]
 
     resources = [
-      "${local.sls_lambda_role_arn}",
+      "${local.lambda_role_arn}",
     ]
   }
 

--- a/role-lambda.tf
+++ b/role-lambda.tf
@@ -1,4 +1,6 @@
 locals {
+  # If the user provides a custom lambda role, don't create the default role,
+  # but still attach the policies that we'd attach to the default role.
   count = "${var.lambda_role_name != "" ? 0 : 1}"
 }
 
@@ -51,6 +53,7 @@ resource "aws_iam_role_policy_attachment" "lambda" {
 #
 # See: https://theburningmonk.com/2019/03/making-terraform-and-serverless-framework-work-together/
 resource "aws_cloudformation_stack" "outputs_lambda_role" {
+  # Only create the stack if we create the default role
   count = "${local.count}"
   name  = "tf-${var.service_name}-${var.stage}-outputs-lambda-role"
 

--- a/role-lambda.tf
+++ b/role-lambda.tf
@@ -1,0 +1,76 @@
+locals {
+  count = "${var.lambda_role_name != "" ? 0 : 1}"
+}
+
+resource "aws_iam_role" "lambda" {
+  count              = "${local.count}"
+  name               = "tf-${var.service_name}-${var.stage}-lambda-execution"
+  assume_role_policy = "${data.aws_iam_policy_document.lambda_assume.json}"
+}
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_policy" "lambda" {
+  name   = "tf-${var.service_name}-${var.stage}-lambda-execution"
+  policy = "${data.aws_iam_policy_document.lambda.json}"
+}
+
+# Replicate the log permissions from the default Serverless role.
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    actions   = ["logs:CreateLogStream"]
+    resources = ["arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group:/aws/lambda/${local.sls_service_name}-${local.iam_stage}*:*"]
+  }
+
+  statement {
+    actions   = ["logs:PutLogEvents"]
+    resources = ["arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group:/aws/lambda/${local.sls_service_name}-${local.iam_stage}*:*:*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "lambda" {
+  role       = "${local.lambda_role_name}"
+  policy_arn = "${aws_iam_policy.lambda.arn}"
+}
+
+# Use a small CloudFormation stack to expose outputs for
+# consumption in Serverless. (There are _many_ ways to do this, we just
+# like this as there's no local disk state needed to deploy.)
+#
+# _Note_: CF **requires** 1+ `Resources`, so we throw in the SSM param of the
+# role ARN because it's small and we need "something". It's otherwise unused.
+#
+# See: https://theburningmonk.com/2019/03/making-terraform-and-serverless-framework-work-together/
+resource "aws_cloudformation_stack" "outputs_lambda_role" {
+  count = "${local.count}"
+  name  = "tf-${var.service_name}-${var.stage}-outputs-lambda-role"
+
+  template_body = <<STACK
+Resources:
+  LambdaExecutionRoleArn:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: "tf-${var.service_name}-${var.stage}-LambdaExecutionRoleArn"
+      Value: "${aws_iam_role.lambda.arn}"
+      Type: String
+
+Outputs:
+  LambdaExecutionRoleArn:
+    Description: "The ARN of the lambda execution role for Serverless to apply"
+    Value: "${aws_iam_role.lambda.arn}"
+    Export:
+      Name: "tf-${var.service_name}-${var.stage}-LambdaExecutionRoleArn"
+
+STACK
+
+  tags = "${local.tags}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
+  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default. If not specified, the role name defaults to `tf-SERVICE_NAME-STAGE-lambda-execution`."
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "sls_service_name" {
 }
 
 variable "lambda_role_name" {
-  description = "Custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
+  description = "Name of a custom Lambda role to override the default Serverless one. The custom role should provide at least the same level of access as the default."
   default     = ""
 }
 
@@ -82,12 +82,15 @@ variable "opt_many_lambdas" {
   default     = false
 }
 
+data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 # AWS / Serverless framework configuration.
 locals {
+  partition           = "${data.aws_partition.current.partition}"
   iam_partition       = "${var.iam_partition}"
+  account_id          = "${data.aws_caller_identity.current.account_id}"
   iam_account_id      = "${var.iam_account_id != "" ? var.iam_account_id : data.aws_caller_identity.current.account_id}"
   region              = "${var.region != "" ? var.region : data.aws_region.current.name}"
   iam_region          = "${var.iam_region}"
@@ -96,7 +99,6 @@ locals {
   service_name        = "${var.service_name}"
   tf_service_name     = "${var.tf_service_name != "" ? var.tf_service_name : "tf-${var.service_name}"}"
   sls_service_name    = "${var.sls_service_name != "" ? var.sls_service_name : "sls-${var.service_name}"}"
-  lambda_role_name    = "${var.lambda_role_name}"
   role_admin_name     = "${var.role_admin_name}"
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
@@ -114,6 +116,11 @@ locals {
   tf_group_admin_name     = "${local.tf_service_name}-${local.stage}-${local.role_admin_name}"
   tf_group_developer_name = "${local.tf_service_name}-${local.stage}-${local.role_developer_name}"
   tf_group_ci_name        = "${local.tf_service_name}-${local.stage}-${local.role_ci_name}"
+
+  # Resolve the name and ARN for either the default or the custom role.
+  default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
+  lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
+  lambda_role_arn          = "arn:aws:${local.partition}::${local.account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.
   sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"
@@ -133,26 +140,6 @@ locals {
 
   # Serverless lambda function ARN.
   sls_lambda_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:function:${local.sls_service_name}-${local.iam_stage}-*"
-
-  # The built-in serverless Lambda execution role.
-  #
-  # _Note_: We need **actual name** to match real role, which means
-  # `local.region` and not `local.iam_region`.
-  sls_lambda_role_default_name = "${local.sls_service_name}-${local.stage}-${local.region}-lambdaRole"
-
-  # The name, custom or default, of the Lambda execution role to attach policies to.
-  sls_lambda_role_name = "${local.lambda_role_name != "" ? local.lambda_role_name : local.sls_lambda_role_default_name}"
-
-  # The built-in serverless Lambda execution role ARN.
-  #
-  # Note that we use `iam_region` to potentially wildcard the IAM permission
-  # in the actual name of the role.
-  #
-  # - No region allowed in ARN. See https://iam.cloudonaut.io/reference/iam.html
-  sls_lambda_role_default_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.sls_service_name}-${local.iam_stage}-${local.iam_region}-lambdaRole"
-
-  sls_lambda_role_custom_arn = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
-  sls_lambda_role_arn        = "${local.lambda_role_name != "" ? local.sls_lambda_role_custom_arn : local.sls_lambda_role_default_arn}"
 
   # Serverless Lambda Layer ARN.
   sls_layer_arn = "arn:${local.iam_partition}:lambda:${local.iam_region}:${local.iam_account_id}:layer:${local.sls_service_name}-${local.iam_stage}-*"


### PR DESCRIPTION
Creates a new, default Lambda execution IAM role to use in favor of the Serverless default role. This prevents the chicken-and-egg problem where `terraform-aws-serverless` tries to attach IAM policies to the Serverless role that doesn't exist yet.

Added comments in the example `serverless.yml` in the readme to explain the new `role` requirement in `serverless.yml`.

Verified full creation and deletion with both the new default role and a custom role from the reference app: https://github.com/FormidableLabs/aws-lambda-serverless-reference/pull/19