### PR TITLE
Add option to disable group creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ module "serverless" {
   # role_developer_name = `developer`
   # role_ci_name        = `ci`
   # opt_many_lambdas    = false
+  # opt_disable_groups  = false
 }
 ```
 
@@ -218,6 +219,8 @@ Let's unpack the parameters a bit more (located in [variables.tf](variables.tf))
 - `role_developer_name`: The name for the IAM group, policy, etc. for developers. (Default: `developer`).
 - `role_ci_name`: The name for the IAM group, policy, etc. for Continuous Integration (CI) / automation. (Default: `ci`).
 - `opt_many_lambdas`: By default, only the `admin` group can create and delete Lambda functions which gives extra security for a "mono-Lambda" application approach. However, many Lambda applications utilize multiple different functions which need to be created and deleted by the `developer` and `ci` group. Setting this option to `true` enables Lambda function create/delete privileges for all groups. (Default: `false`)
+- `opt_disable_groups`: Disables group and group attachment creation while still creating matching IAM policies. Useful in federated accounts or in environments where access is restricted to assumed roles.
+
 
 Most likely, an AWS superuser will be needed to run the Terraform application for these IAM / other resources.
 

--- a/main.tf
+++ b/main.tf
@@ -13,52 +13,60 @@
 
 # admin
 resource "aws_iam_group" "admin" {
-  name = "${local.tf_group_admin_name}"
+  count = "${local.opt_disable_groups ? 0 : 1}"
+  name  = "${local.tf_group_admin_name}"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_admin" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${aws_iam_group.admin.name}"
   policy_arn = "${aws_iam_policy.admin.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_cd_lambdas" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${aws_iam_group.admin.name}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_developer" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${aws_iam_group.admin.name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 # ci
 resource "aws_iam_group" "ci" {
-  name = "${local.tf_group_ci_name}"
+  count = "${local.opt_disable_groups ? 0 : 1}"
+  name  = "${local.tf_group_ci_name}"
 }
 
 resource "aws_iam_group_policy_attachment" "ci_developer" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${aws_iam_group.ci.name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "ci_cd_lambdas" {
-  count      = "${local.opt_many_lambdas ? 1 : 0}"
+  count      = "${!local.opt_disable_groups && local.opt_many_lambdas ? 1 : 0}"
   group      = "${aws_iam_group.ci.name}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }
 
 # developer
 resource "aws_iam_group" "developer" {
-  name = "${local.tf_group_developer_name}"
+  count = "${local.opt_disable_groups ? 0 : 1}"
+  name  = "${local.tf_group_developer_name}"
 }
 
 resource "aws_iam_group_policy_attachment" "developer_developer" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${aws_iam_group.developer.name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "developer_cd_lambdas" {
-  count      = "${local.opt_many_lambdas ? 1 : 0}"
+  count      = "${!local.opt_disable_groups && local.opt_many_lambdas ? 1 : 0}"
   group      = "${aws_iam_group.developer.name}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }

--- a/modules/canary/main.tf
+++ b/modules/canary/main.tf
@@ -3,16 +3,19 @@
 ###############################################################################
 
 resource "aws_iam_group_policy_attachment" "admin_developer" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${local.tf_group_admin_name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "developer_developer" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${local.tf_group_developer_name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "ci_developer" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${local.tf_group_ci_name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }

--- a/modules/canary/variables.tf
+++ b/modules/canary/variables.tf
@@ -82,6 +82,11 @@ variable "opt_many_lambdas" {
   default     = false
 }
 
+variable "opt_disable_groups" {
+  description = "Do not create groups, only their policies"
+  default     = false
+}
+
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
@@ -103,6 +108,7 @@ locals {
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
   opt_many_lambdas    = "${var.opt_many_lambdas}"
+  opt_disable_groups  = "${var.opt_disable_groups}"
 
   tags = "${map(
     "Service", "${var.service_name}",

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -9,16 +9,19 @@ resource "aws_iam_role_policy_attachment" "lambda_execution" {
 }
 
 resource "aws_iam_group_policy_attachment" "admin_developer" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${local.tf_group_admin_name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "developer_developer" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${local.tf_group_developer_name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "ci_developer" {
+  count      = "${local.opt_disable_groups ? 0 : 1}"
   group      = "${local.tf_group_ci_name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -82,6 +82,11 @@ variable "opt_many_lambdas" {
   default     = false
 }
 
+variable "opt_disable_groups" {
+  description = "Do not create groups, only their policies"
+  default     = false
+}
+
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
@@ -103,6 +108,7 @@ locals {
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
   opt_many_lambdas    = "${var.opt_many_lambdas}"
+  opt_disable_groups  = "${var.opt_disable_groups}"
 
   tags = "${map(
     "Service", "${var.service_name}",

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -82,6 +82,11 @@ variable "opt_many_lambdas" {
   default     = false
 }
 
+variable "opt_disable_groups" {
+  description = "Do not create groups, only their policies"
+  default     = false
+}
+
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
@@ -103,6 +108,7 @@ locals {
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
   opt_many_lambdas    = "${var.opt_many_lambdas}"
+  opt_disable_groups  = "${var.opt_disable_groups}"
 
   tags = "${map(
     "Service", "${var.service_name}",

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,11 @@ output "iam_policy_ci_arn" {
 output "iam_policy_cd_lambdas_arn" {
   value = "${aws_iam_policy.cd_lambdas.arn}"
 }
+
+output "lambda_role_arn" {
+  value = "${aws_iam_role.lambda.*.arn[0]}"
+}
+
+output "lambda_role_name" {
+  value = "${aws_iam_role.lambda.*.name[0]}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,22 @@
 # Outputs
 
+# Use the dummy list trick to fix conditional outputs.
+# This is only an issue in Terraform versions earlier than 0.12.x.
+# See https://github.com/hashicorp/terraform/issues/9858#issuecomment-386431631
+locals {
+  empty_list = [""]
+}
+
 output "iam_group_admin_name" {
-  value = "${aws_iam_group.admin.name}"
+  value = "${element(concat(local.empty_list, aws_iam_group.admin.*.name), 1)}"
 }
 
 output "iam_group_developer_name" {
-  value = "${aws_iam_group.developer.name}"
+  value = "${element(concat(local.empty_list, aws_iam_group.developer.*.name), 1)}"
 }
 
 output "iam_group_ci_name" {
-  value = "${aws_iam_group.ci.name}"
+  value = "${element(concat(local.empty_list, aws_iam_group.ci.*.name), 1)}"
 }
 
 output "iam_policy_admin_arn" {
@@ -29,9 +36,9 @@ output "iam_policy_cd_lambdas_arn" {
 }
 
 output "lambda_role_arn" {
-  value = "${aws_iam_role.lambda.*.arn[0]}"
+  value = "${element(concat(local.empty_list, aws_iam_role.lambda.*.arn), 1)}"
 }
 
 output "lambda_role_name" {
-  value = "${aws_iam_role.lambda.*.name[0]}"
+  value = "${element(concat(local.empty_list, aws_iam_role.lambda.*.name), 1)}"
 }

--- a/role-lambda.tf
+++ b/role-lambda.tf
@@ -63,13 +63,13 @@ Resources:
     Type: AWS::SSM::Parameter
     Properties:
       Name: "tf-${var.service_name}-${var.stage}-LambdaExecutionRoleArn"
-      Value: "${aws_iam_role.lambda.arn}"
+      Value: "${aws_iam_role.lambda.*.arn[count.index]}"
       Type: String
 
 Outputs:
   LambdaExecutionRoleArn:
     Description: "The ARN of the lambda execution role for Serverless to apply"
-    Value: "${aws_iam_role.lambda.arn}"
+    Value: "${aws_iam_role.lambda.*.arn[count.index]}"
     Export:
       Name: "tf-${var.service_name}-${var.stage}-LambdaExecutionRoleArn"
 

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,11 @@ variable "opt_many_lambdas" {
   default     = false
 }
 
+variable "opt_disable_groups" {
+  description = "Do not create groups, only their policies"
+  default     = false
+}
+
 data "aws_partition" "current" {}
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
@@ -103,6 +108,7 @@ locals {
   role_developer_name = "${var.role_developer_name}"
   role_ci_name        = "${var.role_ci_name}"
   opt_many_lambdas    = "${var.opt_many_lambdas}"
+  opt_disable_groups  = "${var.opt_disable_groups}"
 
   tags = "${map(
     "Service", "${var.service_name}",


### PR DESCRIPTION
In federated environments, creating new groups are often frowned upon or disabled–the alternative being role-based access with temporary credentials. This PR adds an option to disable group and group attachment creation while still providing the underlying IAM policies for use in an assumed role.

Tested creation and destruction with this branch in the reference: https://github.com/FormidableLabs/aws-lambda-serverless-reference/pull/30