### PR TITLE
Fix role ARN bug and use IAM variables

### DIFF
--- a/modules/canary/variables.tf
+++ b/modules/canary/variables.tf
@@ -126,7 +126,6 @@ locals {
   # Resolve the name and ARN for either the default or the custom role.
   default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
   lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
-  lambda_role_arn          = "arn:${local.partition}:iam::${local.account_id}:role/${local.lambda_role_name}"
   lambda_role_iam_arn      = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.

--- a/modules/canary/variables.tf
+++ b/modules/canary/variables.tf
@@ -126,7 +126,8 @@ locals {
   # Resolve the name and ARN for either the default or the custom role.
   default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
   lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
-  lambda_role_arn          = "arn:aws:${local.partition}::${local.account_id}:role/${local.lambda_role_name}"
+  lambda_role_arn          = "arn:${local.partition}:iam::${local.account_id}:role/${local.lambda_role_name}"
+  lambda_role_iam_arn      = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.
   sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -126,7 +126,6 @@ locals {
   # Resolve the name and ARN for either the default or the custom role.
   default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
   lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
-  lambda_role_arn          = "arn:${local.partition}:iam::${local.account_id}:role/${local.lambda_role_name}"
   lambda_role_iam_arn      = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -126,7 +126,8 @@ locals {
   # Resolve the name and ARN for either the default or the custom role.
   default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
   lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
-  lambda_role_arn          = "arn:aws:${local.partition}::${local.account_id}:role/${local.lambda_role_name}"
+  lambda_role_arn          = "arn:${local.partition}:iam::${local.account_id}:role/${local.lambda_role_name}"
+  lambda_role_iam_arn      = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.
   sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -126,7 +126,6 @@ locals {
   # Resolve the name and ARN for either the default or the custom role.
   default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
   lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
-  lambda_role_arn          = "arn:${local.partition}:iam::${local.account_id}:role/${local.lambda_role_name}"
   lambda_role_iam_arn      = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -126,7 +126,8 @@ locals {
   # Resolve the name and ARN for either the default or the custom role.
   default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
   lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
-  lambda_role_arn          = "arn:aws:${local.partition}::${local.account_id}:role/${local.lambda_role_name}"
+  lambda_role_arn          = "arn:${local.partition}:iam::${local.account_id}:role/${local.lambda_role_name}"
+  lambda_role_iam_arn      = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.
   sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"

--- a/policy-admin.tf
+++ b/policy-admin.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "admin" {
     ]
 
     resources = [
-      "${local.lambda_role_arn}",
+      "${local.lambda_role_iam_arn}",
     ]
   }
 

--- a/policy-cd-lambdas.tf
+++ b/policy-cd-lambdas.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "cd_lambdas" {
     ]
 
     resources = [
-      "${local.lambda_role_arn}",
+      "${local.lambda_role_iam_arn}",
     ]
   }
 

--- a/policy-developer.tf
+++ b/policy-developer.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "developer" {
     ]
 
     resources = [
-      "${local.lambda_role_arn}",
+      "${local.lambda_role_iam_arn}",
     ]
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -126,7 +126,7 @@ locals {
   # Resolve the name and ARN for either the default or the custom role.
   default_lambda_role_name = "tf-${var.service_name}-${var.stage}-lambda-execution"
   lambda_role_name         = "${var.lambda_role_name != "" ? var.lambda_role_name : local.default_lambda_role_name}"
-  lambda_role_arn          = "arn:aws:${local.partition}::${local.account_id}:role/${local.lambda_role_name}"
+  lambda_role_iam_arn      = "arn:${local.iam_partition}:iam::${local.iam_account_id}:role/${local.lambda_role_name}"
 
   # Serverless CloudFormation stack ARN.
   sls_cloudformation_arn = "arn:${local.iam_partition}:cloudformation:${local.iam_region}:${local.iam_account_id}:stack/${local.sls_service_name}-${local.iam_stage}/*"


### PR DESCRIPTION
The ARN for the Lambda role was completely broken, missing the `iam` segment and duplicating the partition segment. This PR fixes that and loosens the ARN to use IAM versions of variables.

Tested in development env.