### PR TITLE
Use explicit count.index for Terraform 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,19 +19,19 @@ resource "aws_iam_group" "admin" {
 
 resource "aws_iam_group_policy_attachment" "admin_admin" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${aws_iam_group.admin.name}"
+  group      = "${element(aws_iam_group.admin.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.admin.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_cd_lambdas" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${aws_iam_group.admin.name}"
+  group      = "${element(aws_iam_group.admin.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_developer" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${aws_iam_group.admin.name}"
+  group      = "${element(aws_iam_group.admin.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
@@ -43,13 +43,13 @@ resource "aws_iam_group" "ci" {
 
 resource "aws_iam_group_policy_attachment" "ci_developer" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${aws_iam_group.ci.name}"
+  group      = "${element(aws_iam_group.ci.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "ci_cd_lambdas" {
   count      = "${!local.opt_disable_groups && local.opt_many_lambdas ? 1 : 0}"
-  group      = "${aws_iam_group.ci.name}"
+  group      = "${element(aws_iam_group.ci.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }
 
@@ -61,12 +61,12 @@ resource "aws_iam_group" "developer" {
 
 resource "aws_iam_group_policy_attachment" "developer_developer" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${aws_iam_group.developer.name}"
+  group      = "${element(aws_iam_group.developer.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "developer_cd_lambdas" {
   count      = "${!local.opt_disable_groups && local.opt_many_lambdas ? 1 : 0}"
-  group      = "${aws_iam_group.developer.name}"
+  group      = "${element(aws_iam_group.developer.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }

--- a/main.tf
+++ b/main.tf
@@ -19,19 +19,19 @@ resource "aws_iam_group" "admin" {
 
 resource "aws_iam_group_policy_attachment" "admin_admin" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${element(aws_iam_group.admin.*.name, count.index)}"
+  group      = "${local.tf_group_admin_name}"
   policy_arn = "${aws_iam_policy.admin.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_cd_lambdas" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${element(aws_iam_group.admin.*.name, count.index)}"
+  group      = "${local.tf_group_admin_name}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_developer" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${element(aws_iam_group.admin.*.name, count.index)}"
+  group      = "${local.tf_group_admin_name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
@@ -43,13 +43,13 @@ resource "aws_iam_group" "ci" {
 
 resource "aws_iam_group_policy_attachment" "ci_developer" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${element(aws_iam_group.ci.*.name, count.index)}"
+  group      = "${local.tf_group_ci_name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "ci_cd_lambdas" {
   count      = "${!local.opt_disable_groups && local.opt_many_lambdas ? 1 : 0}"
-  group      = "${element(aws_iam_group.ci.*.name, count.index)}"
+  group      = "${local.tf_group_ci_name}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }
 
@@ -61,12 +61,12 @@ resource "aws_iam_group" "developer" {
 
 resource "aws_iam_group_policy_attachment" "developer_developer" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${element(aws_iam_group.developer.*.name, count.index)}"
+  group      = "${local.tf_group_developer_name}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "developer_cd_lambdas" {
   count      = "${!local.opt_disable_groups && local.opt_many_lambdas ? 1 : 0}"
-  group      = "${element(aws_iam_group.developer.*.name, count.index)}"
+  group      = "${local.tf_group_developer_name}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }

--- a/main.tf
+++ b/main.tf
@@ -19,19 +19,19 @@ resource "aws_iam_group" "admin" {
 
 resource "aws_iam_group_policy_attachment" "admin_admin" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${local.tf_group_admin_name}"
+  group      = "${element(aws_iam_group.admin.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.admin.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_cd_lambdas" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${local.tf_group_admin_name}"
+  group      = "${element(aws_iam_group.admin.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "admin_developer" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${local.tf_group_admin_name}"
+  group      = "${element(aws_iam_group.admin.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
@@ -43,13 +43,13 @@ resource "aws_iam_group" "ci" {
 
 resource "aws_iam_group_policy_attachment" "ci_developer" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${local.tf_group_ci_name}"
+  group      = "${element(aws_iam_group.ci.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "ci_cd_lambdas" {
   count      = "${!local.opt_disable_groups && local.opt_many_lambdas ? 1 : 0}"
-  group      = "${local.tf_group_ci_name}"
+  group      = "${element(aws_iam_group.ci.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }
 
@@ -61,12 +61,12 @@ resource "aws_iam_group" "developer" {
 
 resource "aws_iam_group_policy_attachment" "developer_developer" {
   count      = "${local.opt_disable_groups ? 0 : 1}"
-  group      = "${local.tf_group_developer_name}"
+  group      = "${element(aws_iam_group.developer.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.developer.arn}"
 }
 
 resource "aws_iam_group_policy_attachment" "developer_cd_lambdas" {
   count      = "${!local.opt_disable_groups && local.opt_many_lambdas ? 1 : 0}"
-  group      = "${local.tf_group_developer_name}"
+  group      = "${element(aws_iam_group.developer.*.name, count.index)}"
   policy_arn = "${aws_iam_policy.cd_lambdas.arn}"
 }


### PR DESCRIPTION
Terraform 0.12 is more strict with `count`–if `count` was 1 in 0.11, it didn't make you use the `count.index` + splat syntax.