### PR TITLE
add permissions so lambda user can teardown lambda cf stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ _VPC submodule_
     - `ec2:DescribeSecurityGroups`
     - `ec2:DescribeVpcs`
     - `ec2:DescribeSubnets`
+    - `ec2:DescribeNetworkInterfaces`
 * Lambda execution role:
     - `ec2:CreateNetworkInterface`
     - `ec2:DescribeNetworkInterfaces`

--- a/modules/vpc/policy-developer.tf
+++ b/modules/vpc/policy-developer.tf
@@ -18,6 +18,7 @@ data "aws_iam_policy_document" "developer" {
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeVpcs",
       "ec2:DescribeSubnets",
+      "ec2:DescribeNetworkInterfaces",
     ]
 
     # Must be wildcard:

--- a/policy-admin.tf
+++ b/policy-admin.tf
@@ -44,6 +44,7 @@ data "aws_iam_policy_document" "admin" {
       "s3:CreateBucket",
       "s3:DeleteBucket",
       "s3:PutBucketPolicy",
+      "s3:DeleteBucketPolicy",
       "s3:GetEncryptionConfiguration",
       "s3:PutEncryptionConfiguration",
     ]


### PR DESCRIPTION
I believe that due to some recent serverless changes there are new permissions required for our `-admin` user to teardown the serverless cf stack.

This PR adds these two permissions.

More detail here: https://github.com/FormidableLabs/aws-lambda-serverless-reference/issues/54
