### PR TITLE
Allow custom tags definition, merged into defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ module "serverless" {
   # role_ci_name        = `ci`
   # opt_many_lambdas    = false
   # opt_disable_groups  = false
+  # tags = {}
 }
 ```
 

--- a/modules/canary/variables.tf
+++ b/modules/canary/variables.tf
@@ -89,6 +89,7 @@ variable "opt_disable_groups" {
 
 variable "tags" {
   description = "Custom tags to provide to all resources that accept tags."
+  type        = map(string)
   default = {
     "Service" = var.service_name,
     "Stage"   = var.stage

--- a/modules/canary/variables.tf
+++ b/modules/canary/variables.tf
@@ -87,6 +87,14 @@ variable "opt_disable_groups" {
   default     = false
 }
 
+variable "tags" {
+  description = "Custom tags to provide to all resources that accept tags."
+  default = {
+    "Service" = var.service_name,
+    "Stage"   = var.stage
+  }
+}
+
 data "aws_partition" "current" {
 }
 
@@ -115,10 +123,7 @@ locals {
   opt_many_lambdas    = var.opt_many_lambdas
   opt_disable_groups  = var.opt_disable_groups
 
-  tags = {
-    "Service" = var.service_name
-    "Stage"   = var.stage
-  }
+  tags = var.tags
 }
 
 # Capture repeated/complicated AWS IAM resources to a single location.
@@ -185,4 +190,3 @@ locals {
   # Needed for `logs:DescribeLogGroups`
   sls_log_stream_all_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group::log-stream:"
 }
-

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -89,6 +89,7 @@ variable "opt_disable_groups" {
 
 variable "tags" {
   description = "Custom tags to provide to all resources that accept tags."
+  type        = map(string)
   default = {
     "Service" = var.service_name,
     "Stage"   = var.stage

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -87,6 +87,14 @@ variable "opt_disable_groups" {
   default     = false
 }
 
+variable "tags" {
+  description = "Custom tags to provide to all resources that accept tags."
+  default = {
+    "Service" = var.service_name,
+    "Stage"   = var.stage
+  }
+}
+
 data "aws_partition" "current" {
 }
 
@@ -115,10 +123,7 @@ locals {
   opt_many_lambdas    = var.opt_many_lambdas
   opt_disable_groups  = var.opt_disable_groups
 
-  tags = {
-    "Service" = var.service_name
-    "Stage"   = var.stage
-  }
+  tags = var.tags
 }
 
 # Capture repeated/complicated AWS IAM resources to a single location.
@@ -185,4 +190,3 @@ locals {
   # Needed for `logs:DescribeLogGroups`
   sls_log_stream_all_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group::log-stream:"
 }
-

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -89,6 +89,7 @@ variable "opt_disable_groups" {
 
 variable "tags" {
   description = "Custom tags to provide to all resources that accept tags."
+  type        = map(string)
   default = {
     "Service" = var.service_name,
     "Stage"   = var.stage

--- a/modules/xray/variables.tf
+++ b/modules/xray/variables.tf
@@ -87,6 +87,14 @@ variable "opt_disable_groups" {
   default     = false
 }
 
+variable "tags" {
+  description = "Custom tags to provide to all resources that accept tags."
+  default = {
+    "Service" = var.service_name,
+    "Stage"   = var.stage
+  }
+}
+
 data "aws_partition" "current" {
 }
 
@@ -115,10 +123,7 @@ locals {
   opt_many_lambdas    = var.opt_many_lambdas
   opt_disable_groups  = var.opt_disable_groups
 
-  tags = {
-    "Service" = var.service_name
-    "Stage"   = var.stage
-  }
+  tags = var.tags
 }
 
 # Capture repeated/complicated AWS IAM resources to a single location.
@@ -185,4 +190,3 @@ locals {
   # Needed for `logs:DescribeLogGroups`
   sls_log_stream_all_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group::log-stream:"
 }
-

--- a/role-lambda.tf
+++ b/role-lambda.tf
@@ -80,4 +80,3 @@ STACK
 
   tags = local.tags
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -89,6 +89,7 @@ variable "opt_disable_groups" {
 
 variable "tags" {
   description = "Custom tags to provide to all resources that accept tags."
+  type        = map(string)
   default = {
     "Service" = var.service_name,
     "Stage"   = var.stage

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,14 @@ variable "opt_disable_groups" {
   default     = false
 }
 
+variable "tags" {
+  description = "Custom tags to provide to all resources that accept tags."
+  default = {
+    "Service" = var.service_name,
+    "Stage"   = var.stage
+  }
+}
+
 data "aws_partition" "current" {
 }
 
@@ -115,10 +123,7 @@ locals {
   opt_many_lambdas    = var.opt_many_lambdas
   opt_disable_groups  = var.opt_disable_groups
 
-  tags = {
-    "Service" = var.service_name
-    "Stage"   = var.stage
-  }
+  tags = var.tags
 }
 
 # Capture repeated/complicated AWS IAM resources to a single location.
@@ -185,4 +190,3 @@ locals {
   # Needed for `logs:DescribeLogGroups`
   sls_log_stream_all_arn = "arn:${local.iam_partition}:logs:${local.iam_region}:${local.iam_account_id}:log-group::log-stream:"
 }
-


### PR DESCRIPTION
Allow users to merge any custom tags into the default tags.

This is useful if there's an existing tagging strategy in place.

It may also be useful to namespace the existing tags used, or at least allow an option to do so. We already use `Service` tags for example - but with a different use case.